### PR TITLE
Update testing code to work with ABI 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasmtime = "11.0.1"
+wasmtime = "20.0.2"
 anyhow = "1.0.72"
 lazy_static = "1.4.0"
 more-asserts = "0.3.1"
 rand = "0.8.5"
 structopt = "0.3.16"
+cfg-if = "0.1"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ The basic usage of this test-framework is provided in the examples/ folder which
 contains mocking of proxy-wasm modules provided in the proxy-wasm-rust-sdk
 examples/.
 
+In order to run the examples:
+
+Compile the wasm module for the example:
+
+```sh
+cd ~/proxy-wasm-rust-sdk/examples/<example_name>
+cargo build --target wasm32-wasi --release
+```
+
+Run the test against the corresponding module
+
+```sh
+cd ~/test-framework
+cargo run --package proxy-wasm-test-framework --example <example_name> ~/src/proxy-wasm-rust-sdk/examples/<example_name>/target/wasm32-wasi/release/proxy_wasm_example_<example_name>.wasm
+```
+
+
 ## Supported
 
 - Low-level expectation setting over most host-side functions that are consumed

--- a/examples/http_headers.rs
+++ b/examples/http_headers.rs
@@ -43,6 +43,9 @@ fn main() -> Result<()> {
             (":path", "/hello"),
             (":authority", "developer"),
         ]))
+        .expect_log(Some(LogLevel::Info), Some("#2 -> :method: GET"))
+        .expect_log(Some(LogLevel::Info), Some("#2 -> :path: /hello"))
+        .expect_log(Some(LogLevel::Info), Some("#2 -> :authority: developer"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some(":path"))
         .returning(Some("/hello"))
         .expect_send_local_response(


### PR DESCRIPTION
This PR makes the test-framework ABI 0.2.0 compatible. Meaning it can run against the main branch of proxy-wasm-rust-sdk. For example the http_headers example works and passes all expectations.

Note that the added imports are placeholders and working functionality will come in a subsequent PR.